### PR TITLE
Fix build failure on iOS SDK 7.1

### DIFF
--- a/iOS/module.xcconfig
+++ b/iOS/module.xcconfig
@@ -1,1 +1,1 @@
-OTHER_LDFLAGS=$(inherited) -framework Security -CommonCrypto
+OTHER_LDFLAGS=$(inherited) -framework Security


### PR DESCRIPTION
When I use iOS SDK 7.1 and Securely (bencoding.securely-iphone-1.2.4.zip) , Application build is failure. CommonCrypto framework is not exist in iOS SDK 7.1 (I found libcommonCrypto.dylib) .  Remove CommonCrypto line on module.xcconfig. I can succeed build and run.

```
[TRACE] clang: error: unknown argument: '-CommonCrypto' [-Wunused-command-line-argument-hard-error-in-future]
[TRACE] clang: note: this will be a hard error (cannot be downgraded to a warning) in the future
[TRACE] clang: error: unknown argument: '-CommonCrypto' [-Wunused-command-line-argument-hard-error-in-future]
[TRACE] clang: note: this will be a hard error (cannot be downgraded to a warning) in the future
[ERROR] ** BUILD FAILED **
[ERROR] The following build commands failed:
[ERROR]         Ld build/Debug-iphonesimulator/Sample.app/Sample normal i386
[ERROR] (1 failure)
```
