### PR TITLE
Android key generation bugfix

### DIFF
--- a/Android/src/bencoding/securely/SecurelyModule.java
+++ b/Android/src/bencoding/securely/SecurelyModule.java
@@ -86,7 +86,7 @@ public class SecurelyModule extends KrollModule
 	@Kroll.method
 	public String generateDerivedKey(String seed) {
 		try {			
-			String genKey = AESCrypto.getRawKey(seed.getBytes()).toString();
+			String genKey = new String(AESCrypto.getRawKey(seed.getBytes()));
 			return genKey;
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
Using .toString in a byte array in Java returns the object ID, not the string representation of the contents. This is critical and should be merged ASAP :)