### PR TITLE
Using final variable as condition for logging.

### DIFF
--- a/Android/src/bencoding/securely/LogHelpers.java
+++ b/Android/src/bencoding/securely/LogHelpers.java
@@ -10,20 +10,21 @@ import org.appcelerator.kroll.common.Log;
 
 public class LogHelpers {
 	
-	private static boolean _writeIfSecure = false;
+	private static final boolean _writeIfSecure = false;
 	public LogHelpers()
 	{
 		super();
 	}
-	
+
+	@Deprecated
 	public static void UpdateSecureWrite(boolean value){
-		_writeIfSecure = value;
-	}	
+		Log.w(SecurelyModule.SECURELY_MODULE_FULL_NAME, "This method has been deprecated and has no effect in this version of the module.");
+	}
 	public static void Level2Log(String message){
 		if(_writeIfSecure){
 			Log.i(SecurelyModule.SECURELY_MODULE_FULL_NAME, message);
-		}	
-	}	
+		}
+	}
 	public static void info(String message){
 		Log.i(SecurelyModule.SECURELY_MODULE_FULL_NAME, message);
 	}

--- a/Android/src/bencoding/securely/SecurelyModule.java
+++ b/Android/src/bencoding/securely/SecurelyModule.java
@@ -40,11 +40,13 @@ public class SecurelyModule extends KrollModule
 	{
 	}
 
+	@Deprecated
 	@Kroll.method
 	public void disableLevel2Logging()
 	{
 		LogHelpers.UpdateSecureWrite(false);
 	}
+	@Deprecated
 	@Kroll.method
 	public void enableLevel2Logging()
 	{


### PR DESCRIPTION
We discovered that the use of the variable `_writeIfSecure` as a condition for logging is a potential security threat when using the Android version of the module.
By disassembling a compiled Android app (using [Baksmali](https://github.com/JesusFreke/smali)) with Securely included, we found this:
```
# static fields
.field private static _writeIfSecure:Z


# direct methods
.method static constructor <clinit>()V
    .registers 1

    .prologue
    .line 13
    const/4 v0, 0x0 // Boolean value for "false"

    sput-boolean v0, Lbencoding/securely/LogHelpers;->_writeIfSecure:Z  // Boolean value assignment

    return-void
.end method
```

We then changed that value to `0x1` and reassembled the app.
Since that variable is used as a condition by LogHelpers.Log2Level(), we managed to get on log a large part of the data handled by the module, including the `secret` property.

This PR solves this problem by declaring `_writeIfSecure` as a `final` constant (this also means that we had to deprecate the method UpdateSecureWrite() ). The compiler automatically discards the code section that depends on that constant, so it's not possible to tamper with the code to log debug informations.
However this means that, to get debug logs while developing an app, one has to change that constant and rebuild the module.